### PR TITLE
CI: Update to upload-artifact v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           ANDROID_CONFIG=cross-android-${ANDROID_CONFIG//_/-}.cbc
           ./cerbero-uninstalled -c ./config/${ANDROID_CONFIG} package -f wpewebkit
       - name: Store packages
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4
         with:
           name: wpe-deps-${{ matrix.target }}
           path: ./wpewebkit-android-${{ matrix.target }}*


### PR DESCRIPTION
Update to v4 of the upload-artifact action, because v3 will stop working after December 4, 2024:

- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Luckily changing the version number is enough, the functionality used has the same behaviour in v4.