### PR TITLE
libsoup, nghttp2: update to 3.6.4 and 1.64.0

### DIFF
--- a/packages/gstreamer-1.0-net.package
+++ b/packages/gstreamer-1.0-net.package
@@ -10,7 +10,7 @@ class Package(custom.GStreamer, package.Package):
     uuid = '2f9ca3f5-3b3b-4b4d-8cc9-6c08f21af807'
     deps = ['gstreamer-1.0-core', 'base-crypto']
 
-    files = ['libsoup:libs', 'libpsl:libs', 'libsrtp:libs',
+    files = ['libsoup:libs', 'nghttp2:libs', 'libpsl:libs', 'libsrtp:libs',
             'libnice:libs:plugins_net', 'srt:libs',
             'gst-plugins-base-1.0:plugins_net', 'gst-plugins-good-1.0:plugins_net',
             'gst-plugins-ugly-1.0:plugins_net', 'gst-plugins-bad-1.0:plugins_net',

--- a/recipes/libsoup.recipe
+++ b/recipes/libsoup.recipe
@@ -4,12 +4,12 @@ from cerbero.tools.libtool import LibtoolLibrary
 
 class Recipe(recipe.Recipe):
     name = 'libsoup'
-    version = '3.4.0'
+    version = '3.6.4'
     licenses = [License.LGPLv2Plus]
     stype = SourceType.TARBALL
     btype = BuildType.MESON
     url = 'gnome://'
-    tarball_checksum = '23efff6ac70f2c1e873507dac52649eec032c1597a4ae951762ce3123789acc9'
+    tarball_checksum = '9b54c76f5276b05bebcaf2b6c2a141a188fc7bb1d0624eda259dac13a6665c8a'
     meson_options = {'vapi': 'disabled', 'tls_check': 'false', 'tests' : 'false'}
     deps = ['libxml2', 'glib', 'glib-networking', 'libpsl', 'nghttp2']
 
@@ -29,7 +29,7 @@ class Recipe(recipe.Recipe):
 
     def post_install(self):
         soup_deps = ['gio-2.0', 'gmodule-2.0', 'gobject-2.0', 'glib-2.0',
-                     'ffi', 'xml2', 'psl', 'z']
+                     'ffi', 'xml2', 'psl', 'z', 'nghttp2']
         if self.config.target_platform not in (Platform.IOS, Platform.DARWIN):
             soup_deps += ['sqlite3']
         # Meson does not generate la files

--- a/recipes/nghttp2.recipe
+++ b/recipes/nghttp2.recipe
@@ -1,12 +1,39 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 
+from cerbero.tools.libtool import LibtoolLibrary
+
+
 class Recipe(recipe.Recipe):
     name = 'nghttp2'
-    version = '1.52.0'
+    version = '1.64.0'
+    licenses = [{License.MIT: ['COPYING']}]
     stype = SourceType.TARBALL
     btype = BuildType.CMAKE
-    url = 'https://github.com/nghttp2/nghttp2/releases/download/v{0}/nghttp2-{0}.tar.xz'.format(version)
-    tarball_checksum = '3ea9f0439e60469ad4d39cb349938684ffb929dd7e8e06a7bffe9f9d21f8ba7d'
+    url = 'https://github.com/nghttp2/nghttp2/releases/download/v%(version)s/%(name)s-%(version)s.tar.gz'
+    tarball_checksum = '20e73f3cf9db3f05988996ac8b3a99ed529f4565ca91a49eb0550498e10621e8'
+    cmake_generator = 'ninja'
+    can_msvc = True
+    configure_options = ' -DENABLE_LIB_ONLY=ON -DENABLE_DOC=OFF -DWITH_LIBXML2=OFF -DWITH_JEMALLOC=OFF -DBUILD_STATIC_LIBS=ON '
+    library_type = LibraryType.STATIC
 
     files_libs = ['libnghttp2']
-    files_devel = ['include/nghttp2', '%(libdir)s/pkgconfig/libnghttp2.pc']
+    files_devel = ['include/nghttp2/nghttp2.h', '%(libdir)s/pkgconfig/libnghttp2.pc']
+
+    patches = [
+        f'{name}/0001-Expose-NGHTTP2_STATICLIB-on-the-pkg-config-file.patch'
+    ]
+
+    def prepare(self):
+        # Although it can build both types of library, the static ones
+        # have the `_static` suffix and throw off FilesProvider
+        if self.using_msvc():
+            self.configure_options += ' -DBUILD_SHARED_LIBS=OFF '
+            self.library_type = LibraryType.STATIC
+        else:
+            self.library_type = LibraryType.BOTH
+
+    def post_install(self):
+        libtool_la = LibtoolLibrary('nghttp2', None, None, None, self.config.libdir,
+                self.config.target_platform)
+        libtool_la.save()
+        super().post_install()

--- a/recipes/nghttp2/0001-Expose-NGHTTP2_STATICLIB-on-the-pkg-config-file.patch
+++ b/recipes/nghttp2/0001-Expose-NGHTTP2_STATICLIB-on-the-pkg-config-file.patch
@@ -1,0 +1,39 @@
+From b5fc31efb6c100da399c3660f3ad313b223142cc Mon Sep 17 00:00:00 2001
+From: "L. E. Segovia" <amy@centricular.com>
+Date: Tue, 27 Aug 2024 21:13:41 -0300
+Subject: [PATCH] Expose NGHTTP2_STATICLIB on the pkg-config file
+
+---
+ CMakeLists.txt       | 5 +++++
+ lib/libnghttp2.pc.in | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d500bb4..47c6d43 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -393,6 +393,11 @@ set(exec_prefix     "${CMAKE_INSTALL_PREFIX}")
+ set(libdir          "${CMAKE_INSTALL_FULL_LIBDIR}")
+ set(includedir      "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+ set(VERSION         "${PACKAGE_VERSION}")
++if(BUILD_SHARED_LIBS OR NOT WIN32)
++  set(DEFINE_EXPORT)
++else()
++  set(DEFINE_EXPORT "-DNGHTTP2_STATICLIB")
++endif()
+ # For init scripts and systemd service file (in contrib/)
+ set(bindir          "${CMAKE_INSTALL_FULL_BINDIR}")
+ set(sbindir         "${CMAKE_INSTALL_FULL_SBINDIR}")
+diff --git a/lib/libnghttp2.pc.in b/lib/libnghttp2.pc.in
+index da6938f..2820c84 100644
+--- a/lib/libnghttp2.pc.in
++++ b/lib/libnghttp2.pc.in
+@@ -30,4 +30,4 @@ Description: HTTP/2 C library
+ URL: https://github.com/tatsuhiro-t/nghttp2
+ Version: @VERSION@
+ Libs: -L${libdir} -lnghttp2
+-Cflags: -I${includedir}
++Cflags: -I${includedir} @DEFINE_EXPORT@
+-- 
+2.44.0.windows.1
+


### PR DESCRIPTION
This is a partial cherry-pick from the upstream Cerbero commit that adds the nghttp2 package; but incresing the version numbers of the packages (both libsoup and nghttp2) to their most recent stable versions.

This fixes missing dependencies and improves the existing nghttp2 recipe.

Part-of: <https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1149>

(cherry picked from commit 67cdf40498b542dcd8777eb1853831d77a4fe28f)