### PR TITLE
Do not build taglib testing.

### DIFF
--- a/recipes/taglib.recipe
+++ b/recipes/taglib.recipe
@@ -17,6 +17,7 @@ class Recipe(recipe.Recipe):
         -DWITH_ASF=ON \
         -DBUILD_SHARED_LIBS=1 \
         -DBUILD_STATIC_LIBS=1 \
+        -DBUILD_TESTING=0 \
         -DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE'
     deps = ['zlib']
 


### PR DESCRIPTION
We don't need to build tests for dependencies, as we never run them. Besides, these particular tests fail to build in some environments.