### PR TITLE
cmake: Support using ccache if enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,13 @@ jobs:
         run: |
           ANDROID_CONFIG=${{ matrix.target }}
           ANDROID_CONFIG=cross-android-${ANDROID_CONFIG//_/-}.cbc
-          ./cerbero-uninstalled -c ./config/${ANDROID_CONFIG} bootstrap -y
+          echo 'use_ccache = True' > local.cbc
+          ./cerbero-uninstalled -c local.cbc -c ./config/${ANDROID_CONFIG} bootstrap -y
       - name: Package dependencies
         run: |
           ANDROID_CONFIG=${{ matrix.target }}
           ANDROID_CONFIG=cross-android-${ANDROID_CONFIG//_/-}.cbc
-          ./cerbero-uninstalled -c ./config/${ANDROID_CONFIG} package -f wpewebkit
+          ./cerbero-uninstalled -c local.cbc -c ./config/${ANDROID_CONFIG} package -f wpewebkit
       - name: Store packages
         uses: actions/upload-artifact@v4
         with:

--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -196,6 +196,9 @@ class ModifyEnvBase:
     def setup_toolchain_env_ops(self):
         if self.config.qt5_pkgconfigdir:
             self.append_env('PKG_CONFIG_LIBDIR', self.config.qt5_pkgconfigdir, sep=os.pathsep)
+        if self.config.use_ccache and isinstance(self, CMake):
+            self.set_env('CMAKE_C_COMPILER_LAUNCHER', 'ccache')
+            self.set_env('CMAKE_CXX_COMPILER_LAUNCHER', 'ccache')
         if self.config.target_platform != Platform.WINDOWS:
             return
 
@@ -647,7 +650,8 @@ class CMake (MakefilesBase):
         cxx = self.env.get('CXX', 'g++')
         cflags = self.env.get('CFLAGS', '')
         cxxflags = self.env.get('CXXFLAGS', '')
-        # FIXME: CMake doesn't support passing "ccache $CC"
+        # CMake doesn't support passing "ccache $CC", but we can use
+        # the CMAKE_<lang>_COMPILER_LAUNCHER environment variables.
         if self.config.use_ccache:
             cc = cc.replace('ccache', '').strip()
             cxx = cxx.replace('ccache', '').strip()


### PR DESCRIPTION
Setting `CMAKE_<language>_COMPILER_LAUNCHER` in the environment prior to the CMake invocation it will arrange the generated Make/Ninja build files to properly use `ccache` for compiler invocations.