### PR TITLE
CI: Add input to allow cleaning build tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
           - 'dry-run'
           - 'skip'
           - 'yes'
+      clean_build_tools:
+        description: 'Clean build-tools'
+        required: true
+        type: boolean
+        default: false
   pull_request:
     types:
       - opened
@@ -42,6 +47,11 @@ jobs:
           local_sources = "$HOME/cerbero-sources"
           home_dir = "$HOME/cerbero-build-$ANDROID_ARCH"
           EOF
+      - name: Clean build tools
+        if: ${{ inputs.clean_build_tools }}
+        run: |
+          ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \
+            wipe --keep-sources --build-tools --force
       - name: Bootstrap Cerbero
         run: |
           ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \


### PR DESCRIPTION
Add a new input field that may be used for manual workflow runs which enables cleaning the Cerbero build tools. This might be needed on occasion if their recipes introduce incompatible changes.