### PR TITLE
Fix the build with GCC 15 and CMake 4

### DIFF
--- a/recipes/build-tools/m4.recipe
+++ b/recipes/build-tools/m4.recipe
@@ -13,7 +13,7 @@ class Recipe(recipe.Recipe):
 
     def prepare(self):
         self.configure_options += " --disable-gcc-warnings"
-        self.append_env('CFLAGS', '-Wno-error=cast-align')
+        self.append_env('CFLAGS', '-Wno-error=cast-align', '-std=gnu17')
 
     def post_install(self):
         # HACK m4 build fails in Windows gmp build:

--- a/recipes/build-tools/m4.recipe
+++ b/recipes/build-tools/m4.recipe
@@ -22,4 +22,4 @@ class Recipe(recipe.Recipe):
         if self.config.platform == Platform.WINDOWS:
             shutil.move(os.path.join(self.config.prefix, 'bin', 'm4.exe'),
                         os.path.join(self.config.prefix, 'bin', 'm4.exe.backup'))
- 
+        super().post_install()

--- a/recipes/srt.recipe
+++ b/recipes/srt.recipe
@@ -14,7 +14,9 @@ class Recipe(recipe.Recipe):
     cmake_generator = 'ninja'
     can_msvc = False
     # CXX11 builds stuff we don't need, and causes a build failure on mingw
-    configure_options = '-DUSE_ENCLIB=openssl -DENABLE_CXX11=OFF'
+    configure_options = '-DUSE_ENCLIB=openssl \
+        -DENABLE_CXX11=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
     # openssl on Linux
     use_system_libs = True
 

--- a/recipes/taglib.recipe
+++ b/recipes/taglib.recipe
@@ -18,7 +18,8 @@ class Recipe(recipe.Recipe):
         -DBUILD_SHARED_LIBS=1 \
         -DBUILD_STATIC_LIBS=1 \
         -DBUILD_TESTING=0 \
-        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE'
+        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
     deps = ['zlib']
 
     can_msvc = True

--- a/recipes/wavpack.recipe
+++ b/recipes/wavpack.recipe
@@ -18,7 +18,8 @@ class Recipe(recipe.Recipe):
         -DWAVPACK_BUILD_DOCS=OFF \
         -DWAVPACK_BUILD_PROGRAMS=OFF \
         -DWAVPACK_BUILD_COOLEDIT_PLUGIN=OFF \
-        -DWAVPACK_BUILD_WINAMP_PLUGIN=OFF'
+        -DWAVPACK_BUILD_WINAMP_PLUGIN=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
     can_msvc = True
     cmake_generator = 'ninja'
 

--- a/recipes/wpebackend-android.recipe
+++ b/recipes/wpebackend-android.recipe
@@ -14,7 +14,7 @@ class Recipe(recipe.Recipe):
     files_libs = ['libWPEBackend-android']
     files_devel = ['include/wpe-android']
 
-    configure_options = '-DCMAKE_BUILD_TYPE=Release'
+    configure_options = '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
 
     def prepare(self):
         if self.config.target_platform != Platform.ANDROID:


### PR DESCRIPTION
Cherry pick two commits from upstream Cerbero to fix the build of the `m4` package, and add workarounds to `srt`, `taglib`, `wavpack`, and `wpebackend-android` to allow building them with CMake 4.x

Fixes the build e.g. in Arch Linux. 