### PR TITLE
wpewebkit: Remove unused CMake configuration flags

### DIFF
--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -31,17 +31,13 @@ class Recipe(recipe.Recipe):
     # TODO: support accessibility woff2
     configure_options = '\
         -DPORT=WPE \
-        -DENABLE_ACCESSIBILITY=OFF \
         -DUSE_GSTREAMER_GL=ON \
-        -DUSE_GSTREAMER_NATIVE_VIDEO=ON \
-        -DUSE_GSTREAMER_NATIVE_AUDIO=ON \
         -DUSE_WOFF2=OFF \
         -DENABLE_DOCUMENTATION=OFF \
         -DENABLE_INTROSPECTION=OFF \
         -DENABLE_JOURNALD_LOG=OFF \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DUSE_ATK=OFF \
-        -DUSE_SOUP2=OFF \
         -DUSE_LCMS=OFF \
         -DUSE_AVIF=OFF \
         -DUSE_GBM=OFF \


### PR DESCRIPTION
The following build configuration flags are no longer used in the 2.46.x series and may be safely removed:

- `ENABLE_ACCESSIBILITY` has been superseded by USE_ATK, see https://commits.webkit.org/276392@main
- `USE_GSTREAMER_NATIVE_VIDEO` and `USE_GSTREAMER_NATIVE_AUDIO` are now decided at runtime, see https://commits.webkit.org/276450@main
- `USE_SOUP2` is no longer support in WPE, see https://commits.webkit.org/280683@main