### PR TITLE
Add shared-mime-info

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -58,7 +58,8 @@ class Package(package.Package):
         'sqlite3:libs',
         'xkbcommon:libs',
         'wpewebkit',
-        'zlib:libs'
+        'zlib:libs',
+        'shared-mime-info:share'
     ]
 
     files_devel = ['glib']

--- a/recipes/shared-mime-info.recipe
+++ b/recipes/shared-mime-info.recipe
@@ -1,0 +1,18 @@
+
+class Recipe(recipe.Recipe):
+    name = 'shared-mime-info'
+    version = '2.4'
+    stype = SourceType.TARBALL
+    tarball_checksum = '32dc32ae39ff1c1bf8434dd3b36770b48538a1772bc0298509d034f057005992'
+    url = 'https://gitlab.freedesktop.org/xdg/shared-mime-info/-/archive/%(version)s/shared-mime-info-%(version)s.tar.bz2'
+    tarball_dirname = 'shared-mime-info-%(version)s'
+
+    btype = BuildType.MESON
+    deps = [ 'glib', 'gettext' ]
+
+    licenses = [License.GPLv2Plus]
+
+    library_type = LibraryType.SHARED
+
+    files_bins = ['update-mime-database']
+    files_share = ['share/mime/packages/freedesktop.org.xml', 'share/gettext/its/shared-mime-info.loc', 'share/gettext/its/shared-mime-info.its']

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -27,6 +27,7 @@ class Recipe(recipe.Recipe):
         'libwebp',
         'libwpe',
         'openjpeg',
+        'shared-mime-info'
     ]
     # TODO: support accessibility woff2
     configure_options = '\


### PR DESCRIPTION
shared-mime-info is used by glib to query content types, and we use this for resource loading in ResourceLoader::loadGResource.

I haven't been able to verify that shared-mime-info is properly loaded, so marking this as a draft for now