### PR TITLE
CI: Move cleanup to a separate workflow

### DIFF
--- a/.github/actions/setup-cerbero/action.yml
+++ b/.github/actions/setup-cerbero/action.yml
@@ -1,0 +1,25 @@
+name: Setup Cerbero
+description: >-
+  Creates a Cerbero configuration file and sets the ANDROID_ARCH
+  and ANDROID_CONFIG environment variables.
+
+inputs:
+  target_arch:
+    description: 'Target Architecture'
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ANDROID_ARCH=${{ inputs.target_arch }}
+        ANDROID_ARCH=${ANDROID_ARCH//_/-}
+        tee -a $GITHUB_ENV <<< "ANDROID_ARCH=$ANDROID_ARCH"
+        tee -a $GITHUB_ENV <<< "ANDROID_CONFIG=config/cross-android-$ANDROID_ARCH.cbc"
+        tee local.cbc <<EOF
+        use_ccache = True
+        local_sources = "$HOME/cerbero-sources"
+        home_dir = "$HOME/cerbero-build-$ANDROID_ARCH"
+        EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,6 @@ on:
           - 'dry-run'
           - 'skip'
           - 'yes'
-      clean_build_tools:
-        description: 'Clean build-tools'
-        required: true
-        type: boolean
-        default: false
   pull_request:
     types:
       - opened
@@ -36,22 +31,10 @@ jobs:
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4
-      - name: Configure Cerbero
-        run: |
-          ANDROID_ARCH=${{ matrix.target }}
-          ANDROID_ARCH=${ANDROID_ARCH//_/-}
-          tee -a $GITHUB_ENV <<< "ANDROID_ARCH=$ANDROID_ARCH"
-          tee -a $GITHUB_ENV <<< "ANDROID_CONFIG=config/cross-android-$ANDROID_ARCH.cbc"
-          tee local.cbc <<EOF
-          use_ccache = True
-          local_sources = "$HOME/cerbero-sources"
-          home_dir = "$HOME/cerbero-build-$ANDROID_ARCH"
-          EOF
-      - name: Clean build tools
-        if: ${{ inputs.clean_build_tools }}
-        run: |
-          ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \
-            wipe --keep-sources --build-tools --force
+      - name: Setup Cerbero
+        uses: ./.github/actions/setup-cerbero
+        with:
+          target_arch: ${{ matrix.target }}
       - name: Bootstrap Cerbero
         run: |
           ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \

--- a/.github/workflows/clean-tools.yml
+++ b/.github/workflows/clean-tools.yml
@@ -1,0 +1,21 @@
+name: Clean Build Tools
+on:
+  workflow_dispatch:
+
+jobs:
+  clean:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: [arm64, x86_64]
+    steps:
+      - name: Fetch source code
+        uses: actions/checkout@v4
+      - name: Setup Cerbero
+        uses: ./.github/actions/setup-cerbero
+        with:
+          target_arch: ${{ matrix.target }}
+      - name: Clean Build Tools
+        run: |
+          ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \
+            wipe --keep-sources --build-tools --force


### PR DESCRIPTION
Instead of making the build tools cleanup step part of the regular build workflow, split it into its own to allow triggering it separately. This will make it easier to do a "standalone" cleanup when needed, and then retry failed jobs (that will re-boostrap) for pull requests.