### PR TITLE
wpewebkit: Update to version 2.48.6

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -2,7 +2,7 @@
 
 class Package(package.Package):
     name = 'wpewebkit-core'
-    version = '2.48.5'
+    version = '2.48.6'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/packages/wpewebkit.package
+++ b/packages/wpewebkit.package
@@ -2,7 +2,7 @@
 
 class SDKPackage(package.SDKPackage):
     name = 'wpewebkit'
-    version = '2.48.5'
+    version = '2.48.6'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -2,11 +2,11 @@
 
 class Recipe(recipe.Recipe):
     name = 'wpewebkit'
-    version = '2.48.5'
+    version = '2.48.6'
     stype = SourceType.TARBALL
     btype = BuildType.CMAKE
     url = 'https://wpewebkit.org/releases/wpewebkit-{0}.tar.xz'.format(version)
-    tarball_checksum = '01f36010705adb14404c56baf033147f7927cc7c6badec81bb141266fcdd8d0b'
+    tarball_checksum = 'e29b76002c5fb9c9883586dddfa9957da1782b01af66decb10669e6f2b2142aa'
     deps = [
         'icu',
         'cairo',


### PR DESCRIPTION
The main changes are fixups and disabling of the MediaSession API on Android, which would need plumbing using platform libraries to be useful. This also drops the last remaining downstream patch, now that there is https://github.com/Igalia/wpe-android/pull/210 that fixes the actual bug.