### PR TITLE
Enable WebXR support in WPE WebKit

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -55,6 +55,7 @@ class Package(package.Package):
         'proxy-libintl:libs',
         'libpsl:libs',
         'openjpeg:libs',
+        'openxr:libs',
         'sqlite3:libs',
         'xkbcommon:libs',
         'wpewebkit',

--- a/recipes/openxr.recipe
+++ b/recipes/openxr.recipe
@@ -1,0 +1,41 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+
+from cerbero.utils import android
+
+class Recipe(recipe.Recipe):
+    name = 'openxr'
+    version = '1.1.52'
+    stype = SourceType.TARBALL
+    url = f'https://github.com/KhronosGroup/OpenXR-SDK/archive/refs/tags/release-{version}.tar.gz'
+    tarball_checksum = '9ace2834c5f86a77df339865bc072e71d766f4348f3914257d8f87ebe64994a9'
+    tarball_name = f'OpenXR-SDK-release-{version}.tar.gz'
+    tarball_dirname = f'OpenXR-SDK-release-{version}'
+
+    licenses = [License.Apachev2]
+
+    btype = BuildType.CMAKE
+    cmake_generator = 'ninja'
+    library_type = LibraryType.SHARED
+
+    files_libs = ['libopenxr_loader']
+    files_devel = ['include/openxr', 'lib/pkgconfig/openxr.pc']
+
+    configure_options = "\
+        -DBUILD_TESTING=OFF \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_CONFORMANCE_TESTS=OFF \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        "
+
+    def prepare(self):
+        if self.config.target_platform == Platform.ANDROID:
+            ndk_path = self.config.env['ANDROID_NDK_TOOLCHAIN_BIN'] + "/../../../../.."
+            android_api = DistroVersion.get_android_api_version(self.config.target_distro_version)
+            android_arch = android.get_android_arch_name(self.config.target_arch)
+            self.configure_options += f' \
+                -DCMAKE_TOOLCHAIN_FILE={ndk_path}/build/cmake/android.toolchain.cmake \
+                -DANDROID_ABI={android_arch} \
+                -DANDROID_PLATFORM=android-{android_api} \
+                -DANDROID_STL=c++_shared \
+                '
+            self.append_env("CXXFLAGS", "-fexceptions")

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -33,6 +33,7 @@ class Recipe(recipe.Recipe):
         'libwebp',
         'libwpe',
         'openjpeg',
+        'openxr',
     ]
     # TODO: support accessibility, woff2, hyphenation
     configure_options = '\
@@ -44,6 +45,7 @@ class Recipe(recipe.Recipe):
         -DENABLE_JOURNALD_LOG=OFF \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_SPEECH_SYNTHESIS=OFF \
+        -DENABLE_WEBXR=ON \
         -DUSE_ATK=OFF \
         -DUSE_LCMS=OFF \
         -DUSE_AVIF=OFF \
@@ -105,12 +107,14 @@ class Recipe(recipe.Recipe):
             -DPNG_LIBRARY={self.config.prefix}/lib/libpng.so \
             -DPNG_INCLUDE_DIR={self.config.prefix}/include \
             '
+        self.append_env('CXXFLAGS', '-DXR_USE_GRAPHICS_API_OPENGL_ES')
         if self.config.target_platform in (Platform.ANDROID):
             arch_src_name = self.config.target_arch
             if self.config.target_arch == Architecture.ARMv7:
                 arch_src_name = 'arm'
             self.configure_options += ' -DCMAKE_SYSTEM_PROCESSOR=' + arch_src_name
             self.configure_options += ' -DANDROID=1'
+            self.append_env('CXXFLAGS', '-DXR_USE_PLATFORM_ANDROID')
             # Placeholder to allow enabling debug externally
             self.append_env('WEBKIT_DEBUG', '')
         else:

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -46,6 +46,8 @@ class Recipe(recipe.Recipe):
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_SPEECH_SYNTHESIS=OFF \
         -DENABLE_WEBXR=ON \
+        -DENABLE_WEBXR_LAYERS=ON \
+        -DENABLE_WEBXR_HIT_TEST=ON \
         -DUSE_ATK=OFF \
         -DUSE_LCMS=OFF \
         -DUSE_AVIF=OFF \


### PR DESCRIPTION
This includes two commits: one adds a new `openxr` build recipe, for the OpenXR SDK; the other makes the needed changes to actually enable WebXR support in the `wpewebkit` recipes.

----

Note that I would recommend merging this _after_ https://github.com/Igalia/wpe-android-cerbero/pull/80 even if the code builds with 2.48.x, because the WebXR support in 2.50.x is considerably improved.

**Important:** the WebXR support has been tested with additional patches from the `main` branch of WebKit applied on top of 2.50.0, so this may build but not actually run. The idea of this PR is to show what's needed. My plan is to keep the WebXR support disabled in the stable 2.50 branch (to be created after https://github.com/Igalia/wpe-android-cerbero/pull/80 is merged) and only then make the `main` branch build against snapshots built from the WebKit `main` branch. 