### PR TITLE
CI: Run builds when targeting stable branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ on:
       - closed
     branches:
       - 'main'
+      - 'wpewebkit-2.[0-9][0-9]'
 
 jobs:
   build:


### PR DESCRIPTION
Allow running the `build` job when targeting stable branches. If it was possible to use a regular expression to match branch names, this would use

```
  ^wpewebkit-[0-9]+\.[0-9]+$
```

but as that is not possible, this matches instead branches with the `wpewebkit-2.` prefix followed by two more characters (matching only numbers is not possible).