### PR TITLE
Fix source URL for OpenSSL and GNU packages

### DIFF
--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -33,7 +33,7 @@ import cerbero.utils.messages as m
 
 URL_TEMPLATES = {
     'gnome': ('https://download.gnome.org/sources/', '%(name)s/%(maj_ver)s/%(name)s-%(version)s', '.tar.xz'),
-    'gnu': ('https://ftp.gnu.org/gnu/', '%(name)s/%(name)s-%(version)s', '.tar.xz'),
+    'gnu': ('https://ftpmirror.gnu.org/', '%(name)s/%(name)s-%(version)s', '.tar.xz'),
     'savannah': ('https://download.savannah.gnu.org/releases/', '%(name)s/%(name)s-%(version)s', '.tar.xz'),
     'sf': ('https://download.sourceforge.net/', '%(name)s/%(name)s-%(version)s', '.tar.xz'),
     'xiph': ('https://downloads.xiph.org/releases/', '%(name)s/%(name)s-%(version)s', '.tar.xz'),

--- a/recipes-toolchain/mpc.recipe
+++ b/recipes-toolchain/mpc.recipe
@@ -3,7 +3,7 @@
 class Recipe(recipe.Recipe):
     name = 'mpc'
     version = '1.1.0'
-    url = 'https://ftp.gnu.org/gnu/mpc/mpc-%(version)s.tar.gz'
+    url = 'https://ftpmirror.gnu.org/mpc/mpc-%(version)s.tar.gz'
     tarball_checksum = '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e'
     stype = SourceType.TARBALL
     licenses = [License.LGPLv2_1Plus]

--- a/recipes/gettext.recipe
+++ b/recipes/gettext.recipe
@@ -4,7 +4,7 @@ class Recipe(recipe.Recipe):
     name = 'gettext'
     version = '0.21'
     stype = SourceType.TARBALL
-    url = 'https://ftp.gnu.org/pub/gnu/gettext/gettext-{0}.tar.gz'.format(version)
+    url = 'https://ftpmirror.gnu.org/gettext/gettext-{0}.tar.gz'.format(version)
     tarball_checksum = 'c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12'
     srcdir = 'gettext-runtime'
 

--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -11,7 +11,7 @@ class Recipe(recipe.Recipe):
     version = '1.1.1s'
     licenses = [{License.OPENSSL: ['LICENSE']}]
     stype = SourceType.TARBALL
-    url = 'https://github.com/openssl/openssl/releases/download/OpenSSL_{0}/openssl-{1}.tar.gz'.format(version.replace('.','_'), version)
+    url = 'https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1s/{0}-{1}.tar.gz'.format(name, version)
     tarball_checksum = 'c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa'
     deps = ['ca-certificates', 'zlib']
     # Parallel make fails randomly due to undefined macros, probably races


### PR DESCRIPTION
Fix the format for the OpenSSL source location.

Change the GNU URL template from ftp.gnu.org to ftpmirror.gnu.org. Update gettext and mpc recipes to use that mirror.