### PR TITLE
CI: Allow try-builds for the merge-queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,12 @@ on:
     branches:
       - 'main'
       - 'wpewebkit-2.[0-9][0-9]'
+  merge_group:
+    types:
+      - check_requested
 
 jobs:
   build:
-    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request') }}
     runs-on: self-hosted
     strategy:
       matrix:
@@ -48,6 +50,7 @@ jobs:
             package -f wpewebkit
       - name: Store packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request') }}
         with:
           name: wpe-deps-${{ matrix.target }}
           path: ./wpewebkit-android-${{ matrix.target }}*


### PR DESCRIPTION
GitHub Actions now allows using a merge-queue to land PRs. Build jobs can run as checks by the merge-queue if marked accordingly.

----

[Documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group)