### PR TITLE
libpng: update to 1.6.56

### DIFF
--- a/recipes/libpng.recipe
+++ b/recipes/libpng.recipe
@@ -4,14 +4,14 @@ from cerbero.tools.libtool import LibtoolLibrary
 
 class Recipe(recipe.Recipe):
     name = 'libpng'
-    version = '1.6.55'
+    version = '1.6.56'
     stype = SourceType.TARBALL
     btype = BuildType.CMAKE
     library_type = LibraryType.BOTH
     cmake_generator = 'ninja'
     can_msvc = True
     url = 'sf://'
-    tarball_checksum = 'd925722864837ad5ae2a82070d4b2e0603dc72af44bd457c3962298258b8e82d'
+    tarball_checksum = 'f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18'
     licenses = [{License.LibPNG: ['LICENSE']}]
     deps = ['zlib']
     patches = [


### PR DESCRIPTION
Fixes CVEs with IDs CVE-2026-33416, CVE-2026-33636, and includes a number of smaller fixes.