### PR TITLE
Removing cairo as a dependency from wpewebkit

### DIFF
--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -16,7 +16,6 @@ class Recipe(recipe.Recipe):
 
     deps = [
         'icu',
-        'cairo',
         'freetype',
         'gettext',
         'gstreamer-1.0',


### PR DESCRIPTION
Removing cairo as a dependency from wpewebkit, it is not needed