### PR TITLE
CI: Update to avoid deprecated GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,9 @@ jobs:
         target: [arm64, x86_64]
     steps:
       - name: Fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Cerbero
         uses: ./.github/actions/setup-cerbero
         with:
@@ -45,7 +47,7 @@ jobs:
           ./cerbero-uninstalled -t -c local.cbc -c "${ANDROID_CONFIG}" \
             package -f wpewebkit
       - name: Store packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wpe-deps-${{ matrix.target }}
           path: ./wpewebkit-android-${{ matrix.target }}*

--- a/.github/workflows/clean-tools.yml
+++ b/.github/workflows/clean-tools.yml
@@ -10,7 +10,9 @@ jobs:
         target: [arm64, x86_64]
     steps:
       - name: Fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Cerbero
         uses: ./.github/actions/setup-cerbero
         with:


### PR DESCRIPTION
Actions that use Node 20 are deprecated and will stop working on June 2nd, 2026:

  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Therefore, update the versions used for actions/checkout and actions/upload-artifact. While at it, pin the exact revisions to use to further improve reproducibility, and tighten credentials usage.