### PR TITLE
wpewebkit: Bump WPE WebKit to 2.53.2

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -2,7 +2,7 @@
 
 class Package(package.Package):
     name = 'wpewebkit-core'
-    version = '2.51.93'
+    version = '2.53.2'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/packages/wpewebkit.package
+++ b/packages/wpewebkit.package
@@ -2,7 +2,7 @@
 
 class SDKPackage(package.SDKPackage):
     name = 'wpewebkit'
-    version = '2.51.93'
+    version = '2.53.2'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \


### PR DESCRIPTION
CI builds the APK against the WPE WebKit version that bootstrap.py fetches. We need to upgrade with the right version and upload a package to allow the CI to work properly.

We need to generate a package and upload when this lands.