### PR TITLE
recipe: fix BuildSteps.all_names() on Python 3.13

### DIFF
--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -166,7 +166,7 @@ class BuildSteps(object):
     @classmethod
     def all_names(cls):
         members = inspect.getmembers(cls, lambda x: isinstance(x, tuple))
-        return tuple(e[1][1] for e in members)
+        return tuple(e[1][1] for e in members if not e[0].startswith('__'))
 
 
 class Recipe(FilesProvider, metaclass=MetaRecipe):

--- a/recipes/build-tools/ninja.recipe
+++ b/recipes/build-tools/ninja.recipe
@@ -8,7 +8,8 @@ class Recipe(recipe.Recipe):
     stype = SourceType.TARBALL
     url = 'https://github.com/ninja-build/ninja/archive/v%(version)s.tar.gz'
     tarball_checksum = '31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea'
-    patches = ['ninja/0001-configure.py-Look-for-cl.exe-before-assuming-MSVC.patch']
+    patches = ['ninja/0001-configure.py-Look-for-cl.exe-before-assuming-MSVC.patch',
+               'ninja/0002-configure.py-use-shlex-instead-of-removed-pipes-modu.patch']
 
     files_bin = ['bin/ninja']
 

--- a/recipes/build-tools/ninja/0002-configure.py-use-shlex-instead-of-removed-pipes-modu.patch
+++ b/recipes/build-tools/ninja/0002-configure.py-use-shlex-instead-of-removed-pipes-modu.patch
@@ -1,0 +1,34 @@
+From 48f525e22a65f7608084aab99a3b27be14ad0a16 Mon Sep 17 00:00:00 2001
+From: "Alejandro G. Castro" <alex@igalia.com>
+Date: Thu, 30 Jul 2026 12:36:43 +0200
+Subject: [PATCH] configure.py: use shlex instead of removed pipes module
+
+---
+ configure.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.py b/configure.py
+index f5e5e3b..56f31fb 100755
+--- a/configure.py
++++ b/configure.py
+@@ -23,7 +23,7 @@ from __future__ import print_function
+ 
+ from optparse import OptionParser
+ import os
+-import pipes
++import shlex
+ import string
+ import subprocess
+ import sys
+@@ -268,7 +268,7 @@ n.variable('configure_args', ' '.join(configure_args))
+ env_keys = set(['CXX', 'AR', 'CFLAGS', 'CXXFLAGS', 'LDFLAGS'])
+ configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
+ if configure_env:
+-    config_str = ' '.join([k + '=' + pipes.quote(configure_env[k])
++    config_str = ' '.join([k + '=' + shlex.quote(configure_env[k])
+                            for k in configure_env])
+     n.variable('configure_env', config_str + '$ ')
+ n.newline()
+-- 
+2.43.0
+


### PR DESCRIPTION
Python 3.13 does not work and it is what we support in the CI.