### PR TITLE
wpewebkit: bump WebKit to 9491626 (2.53.3.7)

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -2,7 +2,7 @@
 
 class Package(package.Package):
     name = 'wpewebkit-core'
-    version = '2.53.3.6'
+    version = '2.53.3.7'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/packages/wpewebkit.package
+++ b/packages/wpewebkit.package
@@ -2,7 +2,7 @@
 
 class SDKPackage(package.SDKPackage):
     name = 'wpewebkit'
-    version = '2.53.3.6'
+    version = '2.53.3.7'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -7,7 +7,7 @@ class Recipe(recipe.Recipe):
     remotes = {'origin' : 'https://github.com/WebKit/WebKit.git'}
     partial_clone = True
     version = 'git' #use just 'git' for individual commits or the version string for release tags
-    commit = '028fba0'
+    commit = '9491626'
 
     wpewebkit_commit = os.environ.get('WPEWEBKIT_COMMIT')
     if wpewebkit_commit:
@@ -81,6 +81,7 @@ class Recipe(recipe.Recipe):
     patches = [
         'wpewebkit/0001-WPE-Decouple-touch-driven-scrolling-unconditionally.patch',
         'wpewebkit/0002-Android-Keep-order-based-main-thread-uid-for-the-au.patch',
+        'wpewebkit/0003-WPE-LayoutRect-drop-constexpr-from-infiniteRect-and-.patch',
     ]
 
     files_libs = [

--- a/recipes/wpewebkit/0003-WPE-LayoutRect-drop-constexpr-from-infiniteRect-and-.patch
+++ b/recipes/wpewebkit/0003-WPE-LayoutRect-drop-constexpr-from-infiniteRect-and-.patch
@@ -1,0 +1,43 @@
+From 4c6983e2656545c08a109b70da0111e1ad9cc232 Mon Sep 17 00:00:00 2001
+From: "Alejandro G. Castro" <alex@igalia.com>
+Date: Thu, 6 Aug 2026 09:56:59 +0200
+Subject: [PATCH] [WPE] LayoutRect: drop constexpr from infiniteRect() and
+ renderableInfiniteRect()
+
+318557@main (a727aa27c537, "[GTK][WPE] Content view broken on
+GitLab") marked infiniteRect() and the new renderableInfiniteRect()
+constexpr, but they call the templated LayoutRect(T1, T2, U1, U2)
+constructor, which is not constexpr (nor are the LayoutUnit/LayoutPoint/
+LayoutSize constructors it relies on). Compilers that predate the P2448
+relaxation, such as the Android NDK r27 clang, reject a constexpr
+function that can never produce a constant expression:
+
+  LayoutRect.h:220:33: error: constexpr function never produces a
+  constant expression [-Winvalid-constexpr]
+
+Both callers only use these rects at runtime, so drop the constexpr
+qualifier again instead of making the whole constructor chain constexpr.
+---
+ Source/WebCore/platform/graphics/LayoutRect.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/graphics/LayoutRect.h b/Source/WebCore/platform/graphics/LayoutRect.h
+index ee5378431924..348b079fcaad 100644
+--- a/Source/WebCore/platform/graphics/LayoutRect.h
++++ b/Source/WebCore/platform/graphics/LayoutRect.h
+@@ -217,13 +217,13 @@ public:
+     LayoutRect transposedRect() const { return LayoutRect(m_location.transposedPoint(), m_size.transposedSize()); }
+     bool isInfinite() const;
+ 
+-    static constexpr LayoutRect infiniteRect()
++    static LayoutRect infiniteRect()
+     {
+         // Return a rect that is slightly smaller than the true max rect to allow pixelSnapping to round up to the nearest IntRect without overflowing.
+         return LayoutRect(LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMax(), LayoutUnit::nearlyMax());
+     }
+ 
+-    static constexpr LayoutRect renderableInfiniteRect()
++    static LayoutRect renderableInfiniteRect()
+     {
+         // Return a infinite-like rect whose values are such that, when converted to float pixel values, they can reasonably represent device pixels.
+         return LayoutRect(LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMax() / 16, LayoutUnit::nearlyMax() / 16);


### PR DESCRIPTION
Weekly bump to wpewebkit 2.53.3.7. Adds 0003 that we will try to fix upstream later: 318557@main made
LayoutRect::infiniteRect()/renderableInfiniteRect() constexpr, which the NDK clang rejects (-Winvalid-constexpr) because the LayoutRect constructor chain is not constexpr; drop the qualifier again.