### PR TITLE
wpewebkit: pin OpenXR_DIR to the cerbero prefix

### DIFF
--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -115,6 +115,7 @@ class Recipe(recipe.Recipe):
         glib_compile_resources_path = \
             path.join(self.config.build_tools_prefix, 'bin', 'glib-compile-resources')
         self.configure_options += f' \
+            -DOpenXR_DIR={self.config.prefix}/lib/cmake/openxr \
             -DICU_ROOT={self.config.prefix} \
             -DZLIB_ROOT={self.config.prefix} \
             -DFREETYPE_LIBRARY={self.config.prefix}/lib/libfreetype.so \


### PR DESCRIPTION
OptionsWPE.cmake does find_package(OpenXR REQUIRED CONFIG), and a config-mode search walks host prefixes taken from the environment. Inside the wkdev SDK two of them point at the host jhbuild instal.